### PR TITLE
Make the No JS link work as it should.

### DIFF
--- a/en/bug.xhtml
+++ b/en/bug.xhtml
@@ -43,7 +43,7 @@
       If you trust us, please enable javascript in your web browser(notably NoScript<br />
       for Firefox) and this will offer a simple clean interface to report a problem.</div>
       <div class="message">
-        <p>It is also possible to use <a href="http://bugs.freedesktop.org/enter_bug.cgi?product=LibreOffice;bug_status=UNCONFIRMED;version=?">bugzilla</a>, with a more complex interface, instead to report a problem.</p>
+        <p>It is also possible to use <a href="https://www.libreoffice.org/bugzilla/enter_bug.cgi?product=LibreOffice&bug_status=UNCONFIRMED">bugzilla</a>, with a more complex interface, instead to report a problem.</p>
 	<p>It works on all browsers and when JavaScript is disabled.</p>
       </div>
       <div class="eyecandy"></div>


### PR DESCRIPTION
There was a bug concerning X-Frame Options which blocked the page from loading "foreign" content.
