### PR TITLE
Bugzilla Migration: Update (most) urls to bugs.libreoffice.org

### DIFF
--- a/en/bug.xhtml
+++ b/en/bug.xhtml
@@ -60,7 +60,7 @@
           Assistant</div>
         </div>
         <div class="submission">
-Thank you for using LibreOffice and for helping us improve our software. This assistant will lead you step-by-step through the bug-reporting process. Please submit a separate bug for each issue!<br />For our full-featured bugtracker go to <a href="http://bugs.freedesktop.org">bugs.freedesktop.org</a>
+Thank you for using LibreOffice and for helping us improve our software. This assistant will lead you step-by-step through the bug-reporting process. Please submit a separate bug for each issue!<br />For our full-featured bugtracker go to <a href="http://bugs.libreoffice.org">bugs.libreoffice.org</a>
         </div>
       </div>
       <div class="content">
@@ -99,7 +99,7 @@ Thank you for using LibreOffice and for helping us improve our software. This as
           </div>
 
           <div class="state_failure">
-	      <p>The bug couldn't be submitted. Please try again later or use <a href="https://bugs.freedesktop.org/">bugzilla</a>.</p>
+	      <p>The bug couldn't be submitted. Please try again later or use <a href="https://bugs.libreoffice.org/">bugzilla</a>.</p>
           </div>
 
           <div class="state_success">

--- a/fr/bug.xhtml
+++ b/fr/bug.xhtml
@@ -60,7 +60,7 @@
         <div class="submission">
           Merci d'utiliser LibreOffice. Nous sommes désolés du problème trouvé dans LibreOffice et vous remercions de le rapporter.
 	  Cet assistant va vous guider pas à pas et ainsi aider notre Assurance Qualité à reproduire le problème.
-	  Pour notre traqueur de bugs complet, rendez-vous sur <a href="http://bugs.freedesktop.org">bugs.freedesktop.org</a> (en anglais).
+	  Pour notre traqueur de bugs complet, rendez-vous sur <a href="http://bugs.libreoffice.org">bugs.libreoffice.org</a> (en anglais).
         </div>
       </div>
       <div class="content">


### PR DESCRIPTION
This commit updates most urls from bugs.freedesktop.org ->
bugs.libreoffice.org. We're unable to change $Bugzilla_uri ahead of
time because we'll fail the certificate check, so that change will
have to be merged-in on the day of the Bugzilla migration.
