### PR TITLE
urls: Break out of the BSA's frame for all external URLs

### DIFF
--- a/en/bug.xhtml
+++ b/en/bug.xhtml
@@ -45,7 +45,7 @@
       If you trust us, please enable javascript in your web browser(notably NoScript<br />
       for Firefox) and this will offer a simple clean interface to report a problem.</div>
       <div class="message">
-        <p>It is also possible to use <a href="https://www.libreoffice.org/bugzilla/enter_bug.cgi?product=LibreOffice;bug_status=UNCONFIRMED" target="_blank">bugzilla</a>, with a more complex interface, instead to report a problem.</p>
+        <p>It is also possible to use <a target="_blank" href="https://www.libreoffice.org/bugzilla/enter_bug.cgi?product=LibreOffice;bug_status=UNCONFIRMED">bugzilla</a>, with a more complex interface, instead to report a problem.</p>
 	<p>It works on all browsers and when JavaScript is disabled.</p>
       </div>
       <div class="eyecandy"></div>
@@ -62,7 +62,7 @@
           Assistant</div>
         </div>
         <div class="submission">
-Thank you for using LibreOffice and for helping us improve our software. This assistant will lead you step-by-step through the bug-reporting process. Please submit a separate bug for each issue!<br />For our full-featured bugtracker go to <a href="http://bugs.libreoffice.org">bugs.libreoffice.org</a>
+Thank you for using LibreOffice and for helping us improve our software. This assistant will lead you step-by-step through the bug-reporting process. Please submit a separate bug for each issue!<br />For our full-featured bugtracker go to <a target="_blank" href="http://bugs.libreoffice.org">bugs.libreoffice.org</a>
         </div>
       </div>
       <div class="content">
@@ -95,7 +95,7 @@ Thank you for using LibreOffice and for helping us improve our software. This as
           </div>
 
           <div class="state_failure">
-	      <p>The bug couldn't be submitted. Please try again later or use <a href="https://bugs.libreoffice.org/">bugzilla</a>.</p>
+	      <p>The bug couldn't be submitted. Please try again later or use <a target="_blank" href="https://bugs.libreoffice.org/">bugzilla</a>.</p>
           </div>
 
           <div class="state_success">
@@ -107,7 +107,7 @@ Thank you for using LibreOffice and for helping us improve our software. This as
             <p></p>
             <p>Nobody is perfect and more bugs have been reported.<br />
             Join us in making this release even better.<br />
-            You could help with <a href="https://wiki.documentfoundation.org/Triage_For_Beginners">sorting bugs</a>.</p>
+            You could help with <a target="_blank" href="https://wiki.documentfoundation.org/Triage_For_Beginners">sorting bugs</a>.</p>
           </div>
 
           <div class="state signin">
@@ -179,7 +179,7 @@ Thank you for using LibreOffice and for helping us improve our software. This as
 		    <!-- End of life message to be displayed when a user selects a version
 		         that is listed in unsupported-versions.txt -->
 		    <p>The Document Foundation is no longer supporting this version of LibreOffice as it has reached its
-		      <a href="https://wiki.documentfoundation.org/ReleasePlan#End_of_Life_Releases">End of Life</a>.
+		      <a target="_blank" href="https://wiki.documentfoundation.org/ReleasePlan#End_of_Life_Releases">End of Life</a>.
 		      We encourage you to update to a new release and see if your bug is still present:</p>
 		    <ul>
 		      <li><a target="_blank" href="https://wiki.documentfoundation.org/QA/BSA/Update_LibreOffice#Windows">Windows</a></li>
@@ -235,7 +235,7 @@ Expected behavior:
                 <div class="state state_attach">
                   <input type="hidden" name="contenttypemethod" value="autodetect"></input>
                   <div>
-                    <div class="input-label">Optionally, you can attach any test kit, sample document, screenshot and/or any <a href="https://wiki.documentfoundation.org/BugReport#Providing_extra_information_for_the_developers_-_ADVANCED" target="_blank">advanced information</a>, such as installation logs, backtraces and other similar things which may help with the fixing of this bug. </div>
+                    <div class="input-label">Optionally, you can attach any test kit, sample document, screenshot and/or any <a target="_blank" href="https://wiki.documentfoundation.org/BugReport#Providing_extra_information_for_the_developers_-_ADVANCED">advanced information</a>, such as installation logs, backtraces and other similar things which may help with the fixing of this bug. </div>
 
                     <div class="attach-file">
 	              <input type="file" name="data" />


### PR DESCRIPTION
All external urls need target="_blank" to break out of our frame.
