### PR TITLE
Draw red rects for version/EOL message when 'old versions' selected

### DIFF
--- a/bug/bug.css
+++ b/bug/bug.css
@@ -511,6 +511,12 @@ div:hover.button {
     border: 0;
 }
 
+/* For End of Life work */
+.end-of-life-message {
+  border: 2px solid red;
+  padding: 0px 10px 0px 10px;
+}
+
 /* skin */
 .skin {
     display: none;

--- a/bug/bug.js
+++ b/bug/bug.js
@@ -202,12 +202,19 @@
                   $.bug.state_description();
                 }
 
-                // If this version is unsupported, display a warning
-                // message.
+                // If this version is unsupported
 		if ($.bug.lo_version_id == -2) {
-                    uv_element.show();
+		  // Display a warning message.
+                  uv_element.show();
+                  // Put a red box around the version field
+                  $(".versions.initialized").css('border', '2px solid red');
+                  // Make sure the description elements are hidden.
+                  //$(".state_description").hide();
                 } else {
-                    uv_element.hide();
+                  uv_element.hide();
+                  // Hide any border showing.
+                  $(".versions.initialized").css('border', '');
+                  //$(".state_description").show();
                 }
             });
             $(".select", element).select();
@@ -231,6 +238,7 @@
 
         },
 
+        // What does this state do? Just show the fields here?
         state_description: function() {
             var element = $('.state_description');
             var template = $(".long", element).val();


### PR DESCRIPTION
Notes:
- These rectangles don't follow the current 'standard' method, which
  relies upon specific-sized PNG images. We should probably standardize
  on a pure HTML/CSS/SVG solution.
- There are still several flaws to the logic that allow users to
  bypass the restrictions merely by poking at the state system -- it's
  very brittle and it's hard to visualize the program flow.
