### PR TITLE
Solve issue with change in token-field

### DIFF
--- a/bug/bug.js
+++ b/bug/bug.js
@@ -471,7 +471,10 @@
         get_token: function() {
           $.bug.token = '';
           $.bug.ajax('GET', $.bug.url + '/enter_bug.cgi?product=LibreOffice&bug_status=UNCONFIRMED').pipe(function(data){
-            $.bug.token = data.match(/<input type="hidden" name="token" value="([A-Za-z0-9]{10})">/)[1];
+	    var token = data.match(/<input type="hidden" id="token" name="token" value="([A-Za-z0-9]{10})">/);
+	    if (token = undefined) //old way
+		token = data.match(/<input type="hidden" name="token" value="([A-Za-z0-9]{10})">/);
+	    $.bug.token = token[1];
           });
         },
 


### PR DESCRIPTION
I couldn't really test this patch. As I don't have a login anymore to the server. But the web-request at enter_bug.cgi gives the token-field back with the id-attribute set. So we need to change that also in our code. And this patch should fix bsa#85150
